### PR TITLE
Defer generation of certain error messages until they are displayed

### DIFF
--- a/src/is/L42/common/EndError.java
+++ b/src/is/L42/common/EndError.java
@@ -5,27 +5,38 @@ import static is.L42.tools.General.pushL;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import is.L42.generated.C;
 import is.L42.generated.P;
 import is.L42.generated.Pos;
 
-public abstract class EndError extends RuntimeException{
-  public EndError(List<Pos> poss,String msg){
-    //assert poss!=null: msg;
+public abstract class EndError extends RuntimeException {
+  public EndError(List<Pos> poss,Supplier<String> msg){
     assert msg!=null;
-    if(!msg.isEmpty() && !msg.endsWith("\n")){msg+="\n";}
-    this.msgPart=msg;
+    this.msgPartSupplier=()->{String m = msg.get(); return (!m.isEmpty() && !m.endsWith("\n")) ? m + '\n' : m; };
     this.poss=poss;
     }
   public boolean ismethCallNoCompatibleMdfParametersSignature(){return false;}//override handler
+  public EndError(List<Pos> poss,String msg){
+    //assert poss!=null;
+    assert msg!=null: msg;
+    if(!msg.isEmpty() && !msg.endsWith("\n")) { msg += "\n"; }
+    this.msgPartString = msg;
+    this.msgPartSupplier = null;
+    this.poss=poss;
+    }
+  public String msgPart(){
+    if(msgPartString == null) { msgPartString = msgPartSupplier.get(); }
+    return msgPartString;
+    }
   @Override public String getMessage(){
-    if(msg==null){msg=ErrMsg.posString(poss)+msgPart+computeMsg();}
+    if(msg==null){msg=ErrMsg.posString(poss)+this.msgPart();}
     return msg;
     }
-  public String computeMsg(){return "";};//override handler
   public final List<Pos> poss;
-  private final String msgPart;
+  private String msgPartString;
+  private final Supplier<String> msgPartSupplier;
   private String msg=null;
   public static class InlinedNativeInvalid extends EndError{
     public InlinedNativeInvalid(List<Pos> poss, String msg) { super(poss, msg);}
@@ -76,6 +87,7 @@ public abstract class EndError extends RuntimeException{
     }
   public static class TypeError extends EndError{
     public TypeError(List<Pos> poss, String msg) { super(poss, msg);}
+    public TypeError(List<Pos> poss, Supplier<String> msg) { super(poss, msg);}
     }
   public static class CoherentError extends EndError{
     public CoherentError(List<Pos> poss, String msg) { super(poss, msg);}

--- a/src/is/L42/common/ErrMsg.java
+++ b/src/is/L42/common/ErrMsg.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -246,25 +247,24 @@ public class ErrMsg {
   "Path "+_1+" can not be used as a operator receiver for "+_2
   ;}public static String invalidExpectedTypeForVoidLiteral(Object _1){return
   "\"void\" is only of type \"Void\", but the program requires it to be of type "+_1
-  ;}public static String castOnPathMustBeClass(Object _1){return
-  "cast on paths must have the class modifier, but "+_1+" is provided"
+  ;}public static Supplier<String> castOnPathMustBeClass(Object _1){return
+  ()->"cast on paths must have the class modifier, but "+_1+" is provided"
   ;}public static String subTypeExpected(Object _1,Object _2){return
   "the path "+_1+" is not a subtype of "+_2
   ;}public static String castOnPathOnlyValidIfNotInterface(Object _1){return
   "except for Any, path casts can not be applied on interfaces, but "+_1+" is declared as interface"
   ;}public static String leakedThrow(Object _1){return
   "An "+_1+" is leaked out of this expression"
-  ;}public static String leakedExceptionFromMethCall(Object _1){return
-  "An exception is leaked out of this expression ("+_1+")"
-  ;}public static String methodDoesNotExists(S attempted,List<MWT> others){return
-  methodDoesNotExists(attempted,options(attempted,others))
+  ;}public static Supplier<String> leakedExceptionFromMethCall(Object _1){return
+  ()->"An exception is leaked out of this expression ("+_1+")"
+  ;}public static Supplier<String> methodDoesNotExists(S attempted,List<MWT> others){return
+  ()->methodDoesNotExists(attempted,options(attempted,others))
   ;}public static String methodDoesNotExists(Object attempted,Object others){return
   "Method "+attempted+" does not exists. Existing methods are:\n"+others+"\n"
-
   ;}public static String invalidSetOfMdfs(Object _1){return
   "Invalid set of modifiers for the expected type of a return: "+_1
-  ;}public static String methCallResultIncompatibleWithExpected(Object _1,Object _2){return
-  "for method "+_1+", method call result type is incompatible with the expected modifier: "+_2
+  ;}public static Supplier<String> methCallResultIncompatibleWithExpected(Object _1,Object _2){return
+  ()->"for method "+_1+", method call result type is incompatible with the expected modifier: "+_2
   ;}public static String methCallNoCompatibleMdfParametersSignature(Object _1,Object _2){return
   "Incompatible modifiers for method call.\nFor method "+_1+", method call parameter signature is incompatible with the parameters expected signature: "+_2
   ;}public static String mayLeakUnresolvedFwd(Object _1){return
@@ -335,8 +335,8 @@ public class ErrMsg {
   "methods "+s+", bridging effectful #$ non determinism have modifier "+mdf+", but only {mut,lent,capsule} are allowed"
   ;}public static String bridgeViolatedByFactory(Object bi,Object fi){return
   "methods "+bi+", bridging effectful #$ non determinism could be invoked through factory "+fi+", that has no #$"
-  ;}public static String nonDetermisticErrorOnlyHD(Object m,Object e){return
-  "method "+m+" catches the non deterministic error "+e+". Only #$ methods are allowed to catch non deterministic errors."
+  ;}public static Supplier<String> nonDetermisticErrorOnlyHD(Object m,Object e){return
+  ()->"method "+m+" catches the non deterministic error "+e+". Only #$ methods are allowed to catch non deterministic errors."
   ;}public static String mustHaveCloseState(){return
   "the core library literal must be a close class. Caused by Cache.Now methods"
   ;}public static String mustHaveCloseStateBridge(Object fs,Object bs){return

--- a/src/is/L42/typeSystem/ProgramTypeSystem.java
+++ b/src/is/L42/typeSystem/ProgramTypeSystem.java
@@ -5,6 +5,7 @@ import static is.L42.tools.General.L;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import is.L42.common.EndError;
@@ -27,7 +28,12 @@ import is.L42.translationToJava.NativeDispatch;
 
 public class ProgramTypeSystem {
   Program p;
-  static void errIf(boolean cond,List<Pos> poss,String msg){
+  public static void errIf(boolean cond,List<Pos> poss,String msg){
+    if(cond){
+      throw new EndError.TypeError(poss,msg);
+      }
+    }
+  public static void errIf(boolean cond,List<Pos> poss,Supplier<String> msg){
     if(cond){
       throw new EndError.TypeError(poss,msg);
       }

--- a/tests/is/L42/tests/L42Source/TestDecoratorsErrors/This.L42
+++ b/tests/is/L42/tests/L42Source/TestDecoratorsErrors/This.L42
@@ -91,7 +91,7 @@ TestSum1=(
     expected=S"""
     |Message This.Trait.MethodClash([###]):
     |method Void foo()=(..)
-    |Conflicting implementation: the method is implemented on both side of the sum
+    |Conflicting implementation: the method is implemented on both sides of the sum
     |file:[###]
     """.trim())
   code2a={interface method Void foo()}
@@ -117,7 +117,7 @@ TestRename=(
     expected=S"""
       |Message This.Trait.MethodClash([###]):
       |method Any foo()=(..)
-      |Conflicting implementation: the method is implemented on both side of the sum
+      |Conflicting implementation: the method is implemented on both sides of the sum
       |file:[###]
       """.trim())
   {}:Test"MethodClash->"(
@@ -125,7 +125,7 @@ TestRename=(
     expected=S"""
       |Message This.Trait.MethodClash([###]):
       |method Any foo()=(..)
-      |Conflicting implementation: the method is implemented on both side of the sum
+      |Conflicting implementation: the method is implemented on both sides of the sum
       |file:[###]
       """.trim())
   )
@@ -135,7 +135,7 @@ TestRename2=(
     expected=S"""
       |Message This.Trait.MethodClash([###]):
       |method Void a(This.A a)=(..)
-      |Conflicting implementation: the method is implemented on both side of the sum
+      |Conflicting implementation: the method is implemented on both sides of the sum
       |file:[###]
       """.trim())
   {}:Test"InvalidMap->"(
@@ -183,7 +183,7 @@ TestMethodClashFunky={A=Class:TestError['T=>Trait.MethodClash]:{
   method S expected()=S"""
     |Message [###]
     |method Any foo()=(..)
-    |Conflicting implementation: the method is implemented on both side of the sum
+    |Conflicting implementation: the method is implemented on both sides of the sum
     |file:[###]
     """  
   }B={}:A}

--- a/tests/is/L42/tests/TestTopNorm.java
+++ b/tests/is/L42/tests/TestTopNorm.java
@@ -1067,7 +1067,7 @@ public class TestTopNorm{
       )
     }
   }
-  """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole)
+  """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole).get()
   );}
 @Test public void nonDetErrorRecognizedException(){topFail(EndError.TypeError.class,"""
   {reuse [AdamsTowel]
@@ -1081,7 +1081,7 @@ public class TestTopNorm{
       )
     }
   }
-  """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole)
+  """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole).get()
   );}
 @Test public void nonDetErrorRecognizedReturn(){topFail(EndError.TypeError.class,"""
     {reuse [AdamsTowel]
@@ -1095,7 +1095,7 @@ public class TestTopNorm{
         )
       }
     }
-    """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole)
+    """,ErrMsg.nonDetermisticErrorOnlyHD(hole, hole).get()
     );}
 
 @Test public void forkJoinErrShapeInvalid(){topFail(EndError.TypeError.class,"""

--- a/tests/is/L42/tests/TestTypeSystem.java
+++ b/tests/is/L42/tests/TestTypeSystem.java
@@ -104,7 +104,7 @@ extends AtomicTest.Tester{public static Stream<AtomicTest>test(){return Stream.o
      class method B()
      method Void leaking()[B]=void
      }}
-     """,ErrMsg.leakedExceptionFromMethCall(hole))
+     """,ErrMsg.leakedExceptionFromMethCall(hole).get())
    ),new AtomicTest(()->
    pass("""
    A={B={
@@ -120,7 +120,7 @@ extends AtomicTest.Tester{public static Stream<AtomicTest>test(){return Stream.o
      class method B()
      method Void leaking()[B]=void
      }}
-    """,ErrMsg.leakedExceptionFromMethCall(hole))
+    """,ErrMsg.leakedExceptionFromMethCall(hole).get())
    ),new AtomicTest(()->
    pass("""
    A={B={
@@ -220,7 +220,7 @@ extends AtomicTest.Tester{public static Stream<AtomicTest>test(){return Stream.o
    """)
    ),new AtomicTest(()->fail("""
    C={class method mut This k()}A={B={method class C main()=C.k()}}
-   """,ErrMsg.methCallResultIncompatibleWithExpected(hole,hole))
+   """,ErrMsg.methCallResultIncompatibleWithExpected(hole,hole).get())
    ),new AtomicTest(()->pass("""
    D={class method This k()}A={B={method read Any main()=error D.k()}}
    """)
@@ -488,7 +488,7 @@ extends AtomicTest.Tester{public static Stream<AtomicTest>test(){return Stream.o
      class method Void bar()[D]=void
      }
    A={B={method read Any main()=D.foo()}}
-   """,ErrMsg.leakedExceptionFromMethCall(hole))
+   """,ErrMsg.leakedExceptionFromMethCall(hole).get())
 
    ),new AtomicTest(()->fail("""
    C={


### PR DESCRIPTION
Selection was performed by profiling L42 (all tests run) and selecting
those error messages which consumed more than a few hundred ms of time.